### PR TITLE
docker-compose.ymlから `:version` を削除

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,3 @@
-version: "3.8"
 services:
   db:
     image: mysql:5.7


### PR DESCRIPTION
docker-compose.ymlから `:version` を削除。 
コンテナの立ち上げなどの時に `version is obsolete`という警告が出るようになっていた。 docker compose v2では `:version` が不要になったとのこと。