### PR TITLE
CI: rspec workflow の actions/cache を v4 に更新

### DIFF
--- a/.github/workflows/rspec.yml
+++ b/.github/workflows/rspec.yml
@@ -28,7 +28,7 @@ jobs:
           bundler-cache: true
 
       - name: Cache node modules
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: node_modules
           key: ${{ runner.os }}-node-${{ hashFiles('**/yarn.lock') }}


### PR DESCRIPTION
## 概要
GitHub Actions の非推奨対応として、Rspec 用ワークフローで使用している actions/cache のバージョンを v2 から v4 に更新しました。

## 変更内容
- rspec.yml
  - Cache node modules ステップの uses を actions/cache@v2 → actions/cache@v4 に変更

## 背景
actions/cache v2 は廃止予定のため、ワークフローが自動失敗する可能性がある状態でした。  
v4 へ更新することで、該当の deprecated エラーを解消します。

## 影響範囲
- CI 設定のみ
- アプリケーションコードへの影響なし

## 確認事項
- ワークフロー定義内で actions/cache v1/v2 の残存がないことを確認済み
